### PR TITLE
icalendar >>text<< value contains escaping (\\, \;, \,, \n):

### DIFF
--- a/src/icalendar.mli
+++ b/src/icalendar.mli
@@ -261,6 +261,7 @@ type calendar = cal_prop list * component list
 val parse_datetime: string -> (timestamp, string) result
 val parse : string -> (calendar, string) result
 val pp : calendar Fmt.t
+val equal_calendar : calendar -> calendar -> bool
 
 (* TODO this actually belongs to CalDAV! this is Webdav_xml module! *)
 type comp = [ `Allcomp | `Comp of component_transform list ]


### PR DESCRIPTION
we already unescape during parsing, but we did not escape during writing

we used to fail on the second parse in "parse (to_ics (parse data))" due to
 bad escaping

add a test from a real ics for this

also, TZURL is a caladdress now (URI in RFC), instead of text
use calendar_equal in test instead of polymorphic compare (which failed for
the new test case)

//cc @linse